### PR TITLE
Code Style Standardization: Clang Formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,106 @@
+---
+Language: Java
+BasedOnStyle: Google
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: true
+AlignConsecutiveBitFields: true
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: false                  # Mess with this
+AllowAllParametersOfDeclarationOnNextLine: false    # Mess with this
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+BinPackArguments: true                              # Mess with this
+BinPackParameters: true                             # Mess with this
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: MultiLine                  # Mess with this
+  AfterEnum:       false
+  AfterFunction:   false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+BreakAfterJavaFieldAnnotations: true                # Mess with this
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit: 120
+ContinuationIndentWidth: 4
+DeriveLineEnding: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+JavaImportGroups: ['com', 'me', 'net', 'org', 'java']  # Mess with this
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 1
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard: Auto
+TabWidth: 4
+UseCRLF: false
+UseTab: Never
+...
+

--- a/common/src/main/java/net/dodogang/plume/Plume.java
+++ b/common/src/main/java/net/dodogang/plume/Plume.java
@@ -1,6 +1,7 @@
 package net.dodogang.plume;
 
 import com.google.common.collect.ImmutableList;
+
 import net.dodogang.plume.ash.Environment;
 import net.dodogang.plume.ash.registry.FuelRegistry;
 import net.dodogang.plume.ash.registry.RegistrySupplier;
@@ -19,15 +20,16 @@ import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.world.poi.PointOfInterestType;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-@SuppressWarnings({"FieldCanBeLocal","unused"})
+@SuppressWarnings({"FieldCanBeLocal", "unused"})
 public final class Plume {
     public static final String MOD_NAME = "Plume";
-    public static final String MOD_ID = "plume";
-    public static final Logger LOGGER = LogManager.getLogger(MOD_NAME);
+    public static final String MOD_ID   = "plume";
+    public static final Logger LOGGER   = LogManager.getLogger(MOD_NAME);
 
     public static final boolean runDevTests = Environment.isDevelopmentEnvironment();
 
@@ -43,30 +45,30 @@ public final class Plume {
         if (runDevTests) {
             LOGGER.log(Level.INFO, "Development environment detected! Running dev initialize.");
 
-            ItemGroup itemGroup = new TabbedItemGroup("plume_test",
-                (id) -> {
-                    String ns = id.getNamespace();
-                    return ImmutableList.of(
-                        TabbedItemGroup.createTab(Blocks.DIRT, ns, "unga"),
-                        TabbedItemGroup.createTab(Blocks.BLACK_CONCRETE, ns, "bunga")
-                    );
-                }, () -> new ItemStack(Blocks.STONE)
-            );
+            ItemGroup itemGroup = new TabbedItemGroup("plume_test", (id) -> {
+                String ns = id.getNamespace();
+                return ImmutableList.of(
+                    TabbedItemGroup.createTab(Blocks.DIRT, ns, "unga"),
+                    TabbedItemGroup.createTab(Blocks.BLACK_CONCRETE, ns, "bunga"));
+            }, () -> new ItemStack(Blocks.STONE));
 
-            BlockRegistryBatch blocks = new BlockRegistryBatch(MOD_ID).setDefaultItemSettings(new Item.Settings().group(itemGroup));
+            BlockRegistryBatch blocks =
+                new BlockRegistryBatch(MOD_ID).setDefaultItemSettings(new Item.Settings().group(itemGroup));
 
             TEST_BLOCK = blocks.add("test_block", new Block(AbstractBlock.Settings.copy(Blocks.STONE)));
-            TEST_BEAM_BLOCK = blocks.add("test_beam_block", new BeamBlock(AbstractBlock.Settings.copy(Blocks.OAK_PLANKS)));
-            TEST_CEILING_PLANT_BLOCK = blocks.add("test_ceiling_plant_block", new CeilingPlantBlock(AbstractBlock.Settings.copy(Blocks.GRASS)));
-            TEST_TALL_CEILING_PLANT_BLOCK = blocks.add("test_tall_ceiling_plant_block", new TallCeilingPlantBlock(AbstractBlock.Settings.copy(Blocks.TALL_GRASS)));
-            TEST_TALLER_PLANT_BLOCK = blocks.add("test_taller_plant_block", new TallerPlantBlock(AbstractBlock.Settings.copy(Blocks.TALL_GRASS)));
+            TEST_BEAM_BLOCK =
+                blocks.add("test_beam_block", new BeamBlock(AbstractBlock.Settings.copy(Blocks.OAK_PLANKS)));
+            TEST_CEILING_PLANT_BLOCK = blocks.add(
+                "test_ceiling_plant_block", new CeilingPlantBlock(AbstractBlock.Settings.copy(Blocks.GRASS)));
+            TEST_TALL_CEILING_PLANT_BLOCK = blocks.add(
+                "test_tall_ceiling_plant_block",
+                new TallCeilingPlantBlock(AbstractBlock.Settings.copy(Blocks.TALL_GRASS)));
+            TEST_TALLER_PLANT_BLOCK = blocks.add(
+                "test_taller_plant_block", new TallerPlantBlock(AbstractBlock.Settings.copy(Blocks.TALL_GRASS)));
 
             blocks.register();
 
-            PointOfInterestTypeAppender.appendBlocks(
-                    PointOfInterestType.BUTCHER,
-                    TEST_BLOCK.getInitialValue()
-            );
+            PointOfInterestTypeAppender.appendBlocks(PointOfInterestType.BUTCHER, TEST_BLOCK.getInitialValue());
         }
 
         LOGGER.log(Level.INFO, "Initialized");

--- a/common/src/main/java/net/dodogang/plume/ash/Environment.java
+++ b/common/src/main/java/net/dodogang/plume/ash/Environment.java
@@ -3,7 +3,7 @@ package net.dodogang.plume.ash;
 import me.shedaniel.architectury.annotations.ExpectPlatform;
 
 public final class Environment {
-    private Environment() {}
+    private Environment() { }
 
     @ExpectPlatform
     public static boolean isDevelopmentEnvironment() {

--- a/common/src/main/java/net/dodogang/plume/ash/client/registry/BlockEntityRendererRegistry.java
+++ b/common/src/main/java/net/dodogang/plume/ash/client/registry/BlockEntityRendererRegistry.java
@@ -1,6 +1,7 @@
 package net.dodogang.plume.ash.client.registry;
 
 import me.shedaniel.architectury.annotations.ExpectPlatform;
+
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher;
@@ -18,9 +19,7 @@ public final class BlockEntityRendererRegistry {
      */
     @ExpectPlatform
     public static <T extends BlockEntity> void register(
-            BlockEntityType<T> beType,
-            Function<BlockEntityRenderDispatcher, BlockEntityRenderer<T>> renderer
-    ) {
+        BlockEntityType<T> beType, Function<BlockEntityRenderDispatcher, BlockEntityRenderer<T>> renderer) {
         throw new AssertionError();
     }
 }

--- a/common/src/main/java/net/dodogang/plume/ash/client/registry/BuiltinItemRendererRegistry.java
+++ b/common/src/main/java/net/dodogang/plume/ash/client/registry/BuiltinItemRendererRegistry.java
@@ -1,6 +1,7 @@
 package net.dodogang.plume.ash.client.registry;
 
 import me.shedaniel.architectury.annotations.ExpectPlatform;
+
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher;
@@ -10,7 +11,7 @@ import net.minecraft.item.ItemConvertible;
 import net.minecraft.item.ItemStack;
 
 public final class BuiltinItemRendererRegistry {
-    private BuiltinItemRendererRegistry() {}
+    private BuiltinItemRendererRegistry() { }
 
     /**
      * Registers a renderer for an item.
@@ -35,9 +36,12 @@ public final class BuiltinItemRendererRegistry {
          * @param matrices        the matrix stack
          * @param vertexConsumers the vertex consumer provider
          * @param light           packed lightmap coordinates
-         * @param overlay         the overlay UV passed to {@link net.minecraft.client.render.VertexConsumer#overlay(int)}
+         * @param overlay         the overlay UV passed to {@link
+         *     net.minecraft.client.render.VertexConsumer#overlay(int)}
          */
-        void render(ItemStack stack, ModelTransformation.Mode mode, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay);
+        void render(
+            ItemStack stack, ModelTransformation.Mode mode, MatrixStack matrices,
+            VertexConsumerProvider vertexConsumers, int light, int overlay);
     }
 
     /**

--- a/common/src/main/java/net/dodogang/plume/ash/client/registry/RenderLayerRegistry.java
+++ b/common/src/main/java/net/dodogang/plume/ash/client/registry/RenderLayerRegistry.java
@@ -1,6 +1,7 @@
 package net.dodogang.plume.ash.client.registry;
 
 import me.shedaniel.architectury.annotations.ExpectPlatform;
+
 import net.minecraft.block.Block;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.fluid.Fluid;

--- a/common/src/main/java/net/dodogang/plume/ash/client/registry/SpriteRegistry.java
+++ b/common/src/main/java/net/dodogang/plume/ash/client/registry/SpriteRegistry.java
@@ -1,11 +1,12 @@
 package net.dodogang.plume.ash.client.registry;
 
 import me.shedaniel.architectury.annotations.ExpectPlatform;
+
 import net.minecraft.client.render.TexturedRenderLayers;
 import net.minecraft.util.Identifier;
 
 public final class SpriteRegistry {
-    private SpriteRegistry() {}
+    private SpriteRegistry() { }
 
     /**
      * Registers sprites to be loaded to a specified texture atlas.

--- a/common/src/main/java/net/dodogang/plume/ash/event/InteractionCallback.java
+++ b/common/src/main/java/net/dodogang/plume/ash/event/InteractionCallback.java
@@ -1,6 +1,7 @@
 package net.dodogang.plume.ash.event;
 
 import me.shedaniel.architectury.annotations.ExpectPlatform;
+
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
@@ -9,7 +10,7 @@ import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
 
 public final class InteractionCallback {
-    private InteractionCallback() {}
+    private InteractionCallback() { }
 
     /**
      * Callback for right-clicking a block.

--- a/common/src/main/java/net/dodogang/plume/ash/registry/FuelRegistry.java
+++ b/common/src/main/java/net/dodogang/plume/ash/registry/FuelRegistry.java
@@ -1,10 +1,11 @@
 package net.dodogang.plume.ash.registry;
 
 import me.shedaniel.architectury.annotations.ExpectPlatform;
+
 import net.minecraft.item.ItemConvertible;
 
 public final class FuelRegistry {
-    private FuelRegistry() {}
+    private FuelRegistry() { }
 
     /**
      * Registers items as fuel with a burn time for furnace-like blocks.

--- a/common/src/main/java/net/dodogang/plume/ash/registry/ItemGroupBuilder.java
+++ b/common/src/main/java/net/dodogang/plume/ash/registry/ItemGroupBuilder.java
@@ -1,9 +1,11 @@
 package net.dodogang.plume.ash.registry;
 
 import me.shedaniel.architectury.annotations.ExpectPlatform;
+
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
+
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.List;
@@ -17,7 +19,7 @@ public abstract class ItemGroupBuilder {
     protected Consumer<List<ItemStack>> stacksToDisplay;
 
     protected ItemGroupBuilder(Identifier id) {
-        this.id = id;
+        this.id      = id;
         iconSupplier = () -> ItemStack.EMPTY;
     }
 

--- a/common/src/main/java/net/dodogang/plume/ash/registry/RegistryBatch.java
+++ b/common/src/main/java/net/dodogang/plume/ash/registry/RegistryBatch.java
@@ -1,8 +1,10 @@
 package net.dodogang.plume.ash.registry;
 
 import me.shedaniel.architectury.annotations.ExpectPlatform;
+
 import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.RegistryKey;
+
 import org.jetbrains.annotations.Nullable;
 
 public abstract class RegistryBatch<T> {
@@ -13,7 +15,7 @@ public abstract class RegistryBatch<T> {
 
     protected RegistryBatch(RegistryKey<Registry<T>> registryKey, String modId) {
         this.registryKey = registryKey;
-        this.modId = modId;
+        this.modId       = modId;
 
         this.registered = false;
     }
@@ -51,7 +53,7 @@ public abstract class RegistryBatch<T> {
         registered = true;
         registerImpl();
     }
-    
+
     protected abstract void registerImpl();
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/common/src/main/java/net/dodogang/plume/ash/registry/RegistrySupplier.java
+++ b/common/src/main/java/net/dodogang/plume/ash/registry/RegistrySupplier.java
@@ -13,10 +13,10 @@ public class RegistrySupplier<T> implements Supplier<T> {
     protected T cachedValue;
 
     public RegistrySupplier(Identifier id, Registry<T> registry, T initialValue) {
-        this.id = id;
-        this.registry = registry;
+        this.id           = id;
+        this.registry     = registry;
         this.initialValue = initialValue;
-        this.cachedValue = null;
+        this.cachedValue  = null;
     }
 
     /**

--- a/common/src/main/java/net/dodogang/plume/ash/tag/TagRegistry.java
+++ b/common/src/main/java/net/dodogang/plume/ash/tag/TagRegistry.java
@@ -1,6 +1,7 @@
 package net.dodogang.plume.ash.tag;
 
 import me.shedaniel.architectury.annotations.ExpectPlatform;
+
 import net.minecraft.block.Block;
 import net.minecraft.entity.EntityType;
 import net.minecraft.fluid.Fluid;
@@ -9,7 +10,7 @@ import net.minecraft.tag.Tag;
 import net.minecraft.util.Identifier;
 
 public final class TagRegistry {
-    private TagRegistry() {}
+    private TagRegistry() { }
 
     /**
      * Registers a block tag with the given identifier.

--- a/common/src/main/java/net/dodogang/plume/ash/tag/ToolTags.java
+++ b/common/src/main/java/net/dodogang/plume/ash/tag/ToolTags.java
@@ -1,6 +1,7 @@
 package net.dodogang.plume.ash.tag;
 
 import me.shedaniel.architectury.annotations.ExpectPlatform;
+
 import net.minecraft.item.ItemStack;
 
 /**

--- a/common/src/main/java/net/dodogang/plume/block/BeamBlock.java
+++ b/common/src/main/java/net/dodogang/plume/block/BeamBlock.java
@@ -22,33 +22,41 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@SuppressWarnings({"unused","deprecation"})
+@SuppressWarnings({"unused", "deprecation"})
 public class BeamBlock extends Block implements Waterloggable {
-    public static final BooleanProperty POST = BooleanProperty.of("post");
-    public static final BooleanProperty NORTH = Properties.NORTH;
-    public static final BooleanProperty EAST = Properties.EAST;
-    public static final BooleanProperty SOUTH = Properties.SOUTH;
-    public static final BooleanProperty WEST = Properties.WEST;
-    public static final BooleanProperty UP = Properties.UP;
-    public static final BooleanProperty DOWN = Properties.DOWN;
+    public static final BooleanProperty POST        = BooleanProperty.of("post");
+    public static final BooleanProperty NORTH       = Properties.NORTH;
+    public static final BooleanProperty EAST        = Properties.EAST;
+    public static final BooleanProperty SOUTH       = Properties.SOUTH;
+    public static final BooleanProperty WEST        = Properties.WEST;
+    public static final BooleanProperty UP          = Properties.UP;
+    public static final BooleanProperty DOWN        = Properties.DOWN;
     public static final BooleanProperty WATERLOGGED = Properties.WATERLOGGED;
 
-    public static final Map<Direction, BooleanProperty> PROP_MAP = Util.make(new HashMap<>(),
-        map -> {
-            map.put(Direction.NORTH, NORTH);
-            map.put(Direction.EAST, EAST);
-            map.put(Direction.SOUTH, SOUTH);
-            map.put(Direction.WEST, WEST);
-            map.put(Direction.UP, UP);
-            map.put(Direction.DOWN, DOWN);
-        });
+    public static final Map<Direction, BooleanProperty> PROP_MAP = Util.make(new HashMap<>(), map -> {
+        map.put(Direction.NORTH, NORTH);
+        map.put(Direction.EAST, EAST);
+        map.put(Direction.SOUTH, SOUTH);
+        map.put(Direction.WEST, WEST);
+        map.put(Direction.UP, UP);
+        map.put(Direction.DOWN, DOWN);
+    });
 
     private final ShapeUtil shapeUtil;
 
     public BeamBlock(AbstractBlock.Settings settings) {
         super(settings);
 
-        this.setDefaultState(this.getStateManager().getDefaultState().with(POST, true).with(NORTH, false).with(EAST, false).with(SOUTH, false).with(WEST, false).with(UP, false).with(DOWN, false).with(WATERLOGGED, false));
+        this.setDefaultState(this.getStateManager()
+                                 .getDefaultState()
+                                 .with(POST, true)
+                                 .with(NORTH, false)
+                                 .with(EAST, false)
+                                 .with(SOUTH, false)
+                                 .with(WEST, false)
+                                 .with(UP, false)
+                                 .with(DOWN, false)
+                                 .with(WATERLOGGED, false));
         this.shapeUtil = new ShapeUtil(this);
     }
 
@@ -58,17 +66,24 @@ public class BeamBlock extends Block implements Waterloggable {
 
     private BlockState makeConnections(World world, BlockPos pos) {
         Boolean north = this.isConnectable(world, pos.north(), Direction.SOUTH);
-        Boolean east = this.isConnectable(world, pos.east(), Direction.WEST);
+        Boolean east  = this.isConnectable(world, pos.east(), Direction.WEST);
         Boolean south = this.isConnectable(world, pos.south(), Direction.NORTH);
-        Boolean west = this.isConnectable(world, pos.west(), Direction.EAST);
-        Boolean up = this.isConnectable(world, pos.up(), Direction.DOWN);
-        Boolean down = this.isConnectable(world, pos.down(), Direction.UP);
+        Boolean west  = this.isConnectable(world, pos.west(), Direction.EAST);
+        Boolean up    = this.isConnectable(world, pos.up(), Direction.DOWN);
+        Boolean down  = this.isConnectable(world, pos.down(), Direction.UP);
 
-        return this.getDefaultState().with(NORTH, north).with(EAST, east).with(SOUTH, south).with(WEST, west).with(UP, up).with(DOWN, down);
+        return this.getDefaultState()
+            .with(NORTH, north)
+            .with(EAST, east)
+            .with(SOUTH, south)
+            .with(WEST, west)
+            .with(UP, up)
+            .with(DOWN, down);
     }
 
     @Override
-    public BlockState getStateForNeighborUpdate(BlockState state, Direction direction, BlockState newState, WorldAccess world, BlockPos pos, BlockPos posFrom) {
+    public BlockState getStateForNeighborUpdate(
+        BlockState state, Direction direction, BlockState newState, WorldAccess world, BlockPos pos, BlockPos posFrom) {
         return state.with(getProperty(direction), this.isConnectable(world, posFrom, direction.getOpposite()));
     }
 
@@ -83,7 +98,8 @@ public class BeamBlock extends Block implements Waterloggable {
 
     @Override
     public BlockState getPlacementState(ItemPlacementContext ctx) {
-        return this.makeConnections(ctx.getWorld(), ctx.getBlockPos()).with(POST, ctx.getSide() == Direction.UP || ctx.getSide() == Direction.DOWN);
+        return this.makeConnections(ctx.getWorld(), ctx.getBlockPos())
+            .with(POST, ctx.getSide() == Direction.UP || ctx.getSide() == Direction.DOWN);
     }
 
     @Override
@@ -129,23 +145,20 @@ public class BeamBlock extends Block implements Waterloggable {
 
         public ShapeUtil(BeamBlock beamBlock) {
             this.beamBlock = beamBlock;
-            this.shapes = createStateShapeMap();
+            this.shapes    = createStateShapeMap();
         }
 
         private HashMap<BlockState, VoxelShape> createStateShapeMap() {
             return Util.make(
                 new HashMap<>(),
-                map -> beamBlock.getStateManager().getStates().forEach(
-                    state -> map.put(state, getStateShape(state))
-                )
-            );
+                map -> beamBlock.getStateManager().getStates().forEach(state -> map.put(state, getStateShape(state))));
         }
 
         private VoxelShape getStateShape(BlockState state) {
             final double size = 4;
-            final VoxelShape baseShape = !state.get(POST)
-                ? Block.createCuboidShape(size, size, size, 16.0D - size, 16.0D - size, 16.0D - size)
-                : Block.createCuboidShape(size, 0.0D, size, 16.0D - size, 16.0D, 16.0D - size);
+            final VoxelShape baseShape =
+                !state.get(POST) ? Block.createCuboidShape(size, size, size, 16.0D - size, 16.0D - size, 16.0D - size)
+                                 : Block.createCuboidShape(size, 0.0D, size, 16.0D - size, 16.0D, 16.0D - size);
 
             final List<VoxelShape> connections = new ArrayList<>();
             for (Direction dir : Direction.values()) {

--- a/common/src/main/java/net/dodogang/plume/block/PlumeCraftingTableBlock.java
+++ b/common/src/main/java/net/dodogang/plume/block/PlumeCraftingTableBlock.java
@@ -21,11 +21,9 @@ public class PlumeCraftingTableBlock extends CraftingTableBlock {
     @Override
     public NamedScreenHandlerFactory createScreenHandlerFactory(BlockState state, World world, BlockPos pos) {
         return new SimpleNamedScreenHandlerFactory(
-                (syncId, inventory, player) -> new PlumeCraftingScreenHandler(
-                    syncId,
-                    inventory,
-                    ScreenHandlerContext.create(world, pos),
-                    state.getBlock()
-                ), TITLE);
+            (syncId, inventory, player)
+                -> new PlumeCraftingScreenHandler(
+                    syncId, inventory, ScreenHandlerContext.create(world, pos), state.getBlock()),
+            TITLE);
     }
 }

--- a/common/src/main/java/net/dodogang/plume/block/TallCeilingPlantBlock.java
+++ b/common/src/main/java/net/dodogang/plume/block/TallCeilingPlantBlock.java
@@ -45,19 +45,28 @@ public class TallCeilingPlantBlock extends PlantBlock {
     }
 
     @Override
-    public BlockState getStateForNeighborUpdate(BlockState state, Direction direction, BlockState newState, WorldAccess world, BlockPos pos, BlockPos posFrom) {
+    public BlockState getStateForNeighborUpdate(
+        BlockState state, Direction direction, BlockState newState, WorldAccess world, BlockPos pos, BlockPos posFrom) {
         DoubleBlockHalf doubleBlockHalf = state.get(HALF);
-        if (direction.getAxis() == Direction.Axis.Y && doubleBlockHalf == DoubleBlockHalf.LOWER == (direction == Direction.UP) && (!newState.isOf(this) || newState.get(HALF) == doubleBlockHalf)) {
+        if (direction.getAxis() == Direction.Axis.Y
+            && doubleBlockHalf == DoubleBlockHalf.LOWER == (direction == Direction.UP)
+            && (!newState.isOf(this) || newState.get(HALF) == doubleBlockHalf))
+        {
             return Blocks.AIR.getDefaultState();
         } else {
-            return doubleBlockHalf == DoubleBlockHalf.LOWER && direction == Direction.DOWN && !state.canPlaceAt(world, pos) ? Blocks.AIR.getDefaultState() : super.getStateForNeighborUpdate(state, direction, newState, world, pos, posFrom);
+            return doubleBlockHalf == DoubleBlockHalf.LOWER && direction == Direction.DOWN
+                    && !state.canPlaceAt(world, pos)
+                ? Blocks.AIR.getDefaultState()
+                : super.getStateForNeighborUpdate(state, direction, newState, world, pos, posFrom);
         }
     }
 
     @Override
     public BlockState getPlacementState(ItemPlacementContext ctx) {
         BlockPos blockPos = ctx.getBlockPos();
-        return blockPos.getY() > 0 && ctx.getWorld().getBlockState(blockPos.down()).canReplace(ctx) ? super.getPlacementState(ctx) : null;
+        return blockPos.getY() > 0 && ctx.getWorld().getBlockState(blockPos.down()).canReplace(ctx)
+            ? super.getPlacementState(ctx)
+            : null;
     }
 
     @Override
@@ -77,7 +86,8 @@ public class TallCeilingPlantBlock extends PlantBlock {
     }
 
     @Override
-    public void afterBreak(World world, PlayerEntity player, BlockPos pos, BlockState state, BlockEntity blockEntity, ItemStack stack) {
+    public void afterBreak(
+        World world, PlayerEntity player, BlockPos pos, BlockState state, BlockEntity blockEntity, ItemStack stack) {
         super.afterBreak(world, player, pos, Blocks.AIR.getDefaultState(), blockEntity, stack);
     }
 
@@ -97,7 +107,7 @@ public class TallCeilingPlantBlock extends PlantBlock {
     protected static void onBreakInCreative(World world, BlockPos pos, BlockState state, PlayerEntity player) {
         DoubleBlockHalf doubleBlockHalf = state.get(HALF);
         if (doubleBlockHalf == DoubleBlockHalf.UPPER) {
-            BlockPos blockPos = pos.up();
+            BlockPos blockPos     = pos.up();
             BlockState blockState = world.getBlockState(blockPos);
             if (blockState.getBlock() == state.getBlock() && blockState.get(HALF) == DoubleBlockHalf.LOWER) {
                 world.setBlockState(blockPos, Blocks.AIR.getDefaultState(), 35);
@@ -115,6 +125,7 @@ public class TallCeilingPlantBlock extends PlantBlock {
     @Override
     @Environment(EnvType.CLIENT)
     public long getRenderingSeed(BlockState state, BlockPos pos) {
-        return MathHelper.hashCode(pos.getX(), pos.down(state.get(HALF) == DoubleBlockHalf.LOWER ? 0 : 1).getY(), pos.getZ());
+        return MathHelper.hashCode(
+            pos.getX(), pos.down(state.get(HALF) == DoubleBlockHalf.LOWER ? 0 : 1).getY(), pos.getZ());
     }
 }

--- a/common/src/main/java/net/dodogang/plume/block/TallerPlantBlock.java
+++ b/common/src/main/java/net/dodogang/plume/block/TallerPlantBlock.java
@@ -26,7 +26,8 @@ import java.util.ArrayList;
  */
 @SuppressWarnings("unused")
 public class TallerPlantBlock extends PlantBlock {
-    public static final EnumProperty<TripleBlockPart> PART = EnumProperty.of("triple_block_part", TripleBlockPart.class);
+    public static final EnumProperty<TripleBlockPart> PART =
+        EnumProperty.of("triple_block_part", TripleBlockPart.class);
 
     public TallerPlantBlock(AbstractBlock.Settings settings) {
         super(settings);
@@ -34,14 +35,17 @@ public class TallerPlantBlock extends PlantBlock {
     }
 
     @Override
-    public BlockState getStateForNeighborUpdate(BlockState state, Direction direction, BlockState newState, WorldAccess world, BlockPos pos, BlockPos posFrom) {
+    public BlockState getStateForNeighborUpdate(
+        BlockState state, Direction direction, BlockState newState, WorldAccess world, BlockPos pos, BlockPos posFrom) {
         TripleBlockPart part = state.get(PART);
         if (direction == Direction.UP && part != TripleBlockPart.UPPER) {
             Block block = newState.getBlock();
-            if (block != this) return Blocks.AIR.getDefaultState();
+            if (block != this)
+                return Blocks.AIR.getDefaultState();
         } else if (direction == Direction.DOWN && part != TripleBlockPart.LOWER) {
             Block block = newState.getBlock();
-            if (block != this) return Blocks.AIR.getDefaultState();
+            if (block != this)
+                return Blocks.AIR.getDefaultState();
         }
 
         return super.getStateForNeighborUpdate(state, direction, newState, world, pos, posFrom);
@@ -50,7 +54,8 @@ public class TallerPlantBlock extends PlantBlock {
     @Override
     public BlockState getPlacementState(ItemPlacementContext ctx) {
         BlockPos blockPos = ctx.getBlockPos();
-        return blockPos.getY() < 254 && ctx.getWorld().getBlockState(blockPos.up(1)).canReplace(ctx) && ctx.getWorld().getBlockState(blockPos.up(2)).canReplace(ctx)
+        return blockPos.getY() < 254 && ctx.getWorld().getBlockState(blockPos.up(1)).canReplace(ctx)
+                && ctx.getWorld().getBlockState(blockPos.up(2)).canReplace(ctx)
             ? super.getPlacementState(ctx)
             : null;
     }
@@ -65,7 +70,7 @@ public class TallerPlantBlock extends PlantBlock {
     public boolean canPlaceAt(BlockState state, WorldView world, BlockPos pos) {
         if (state.get(PART) == TripleBlockPart.LOWER) {
             return super.canPlaceAt(state, world, pos);
-        } else if(state.get(PART) == TripleBlockPart.MIDDLE) {
+        } else if (state.get(PART) == TripleBlockPart.MIDDLE) {
             BlockState blockStateDown1 = world.getBlockState(pos.down(1));
             return (blockStateDown1.isOf(this) && blockStateDown1.get(PART) == TripleBlockPart.LOWER);
         } else {
@@ -96,12 +101,13 @@ public class TallerPlantBlock extends PlantBlock {
     }
 
     @Override
-    public void afterBreak(World world, PlayerEntity player, BlockPos pos, BlockState state, BlockEntity blockEntity, ItemStack stack) {
+    public void afterBreak(
+        World world, PlayerEntity player, BlockPos pos, BlockState state, BlockEntity blockEntity, ItemStack stack) {
         super.afterBreak(world, player, pos, Blocks.AIR.getDefaultState(), blockEntity, stack);
     }
 
     protected static void onBreakInCreative(World world, BlockPos pos, BlockState state, PlayerEntity player) {
-        ArrayList<BlockPos> positions = new ArrayList<>();
+        ArrayList<BlockPos> positions   = new ArrayList<>();
         TripleBlockPart tripleBlockPart = state.get(PART);
 
         if (tripleBlockPart == TripleBlockPart.UPPER) {
@@ -135,6 +141,7 @@ public class TallerPlantBlock extends PlantBlock {
     @Override
     @Environment(EnvType.CLIENT)
     public long getRenderingSeed(BlockState state, BlockPos pos) {
-        return MathHelper.hashCode(pos.getX(), pos.down(state.get(PART) == TripleBlockPart.LOWER ? 0 : 1).getY(), pos.getZ());
+        return MathHelper.hashCode(
+            pos.getX(), pos.down(state.get(PART) == TripleBlockPart.LOWER ? 0 : 1).getY(), pos.getZ());
     }
 }

--- a/common/src/main/java/net/dodogang/plume/client/PlumeClient.java
+++ b/common/src/main/java/net/dodogang/plume/client/PlumeClient.java
@@ -1,7 +1,5 @@
 package net.dodogang.plume.client;
 
 public final class PlumeClient {
-    public static void initialize() {
-
-    }
+    public static void initialize() { }
 }

--- a/common/src/main/java/net/dodogang/plume/client/gui/item_group/ItemGroupTab.java
+++ b/common/src/main/java/net/dodogang/plume/client/gui/item_group/ItemGroupTab.java
@@ -16,12 +16,13 @@ public class ItemGroupTab {
     private final Tag<Item> tag;
     private final ItemStack icon;
     private final Identifier id;
-    private Identifier widgetBackgroundTexture = new Identifier(Plume.MOD_ID, "textures/gui/creative_inventory/item_group/tab_widget.png");
+    private Identifier widgetBackgroundTexture =
+        new Identifier(Plume.MOD_ID, "textures/gui/creative_inventory/item_group/tab_widget.png");
 
     public ItemGroupTab(ItemStack icon, Identifier id, Tag<Item> tag) {
-        this.tag = tag;
+        this.tag  = tag;
         this.icon = icon;
-        this.id = id;
+        this.id   = id;
     }
 
     @SuppressWarnings("unused")
@@ -46,7 +47,8 @@ public class ItemGroupTab {
         return tag != null && tag.contains(item);
     }
 
-    public ItemGroupTabWidget createWidget(int x, int y, int selectedTabIndex, TabbedItemGroup tab, CreativeInventoryScreen screen) {
+    public ItemGroupTabWidget createWidget(
+        int x, int y, int selectedTabIndex, TabbedItemGroup tab, CreativeInventoryScreen screen) {
         return new ItemGroupTabWidget(x, y, selectedTabIndex, tab, screen, this.widgetBackgroundTexture);
     }
 }

--- a/common/src/main/java/net/dodogang/plume/client/gui/item_group/ItemGroupTabWidget.java
+++ b/common/src/main/java/net/dodogang/plume/client/gui/item_group/ItemGroupTabWidget.java
@@ -2,6 +2,7 @@ package net.dodogang.plume.client.gui.item_group;
 
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
+
 import net.dodogang.plume.item.item_group.TabbedItemGroup;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -20,14 +21,15 @@ public class ItemGroupTabWidget extends ButtonWidget {
 
     public ItemGroupTabWidget(int x, int y, ItemGroupTab tab, PressAction onPress, Identifier texture) {
         super(x, y, 22, 22, tab.getTranslationKey(), onPress);
-        this.tab = tab;
+        this.tab     = tab;
         this.texture = texture;
     }
-    public ItemGroupTabWidget(int x, int y, int selectedTabIndex, TabbedItemGroup tab, CreativeInventoryScreen screen, Identifier texture) {
+    public ItemGroupTabWidget(
+        int x, int y, int selectedTabIndex, TabbedItemGroup tab, CreativeInventoryScreen screen, Identifier texture) {
         this(x - 24, (y + 12) + (selectedTabIndex * 24), tab.getTabs().get(selectedTabIndex), (btn) -> {
             tab.setSelectedTabIndex(selectedTabIndex);
             MinecraftClient.getInstance().openScreen(screen);
-            ((ItemGroupTabWidget) btn).isSelected = true;
+            ((ItemGroupTabWidget)btn).isSelected = true;
         }, texture);
     }
 
@@ -47,7 +49,8 @@ public class ItemGroupTabWidget extends ButtonWidget {
         RenderSystem.defaultBlendFunc();
         RenderSystem.blendFunc(GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA);
 
-        this.drawTexture(matrices, this.x, this.y, 0, this.getYImage(this.isHovered()) * height, this.width, this.height);
+        this.drawTexture(
+            matrices, this.x, this.y, 0, this.getYImage(this.isHovered()) * height, this.width, this.height);
         this.renderBg(matrices, client, mouseX, mouseY);
 
         client.getItemRenderer().renderInGui(tab.getIcon(), this.x + 3, this.y + 3);

--- a/common/src/main/java/net/dodogang/plume/item/item_group/TabbedItemGroup.java
+++ b/common/src/main/java/net/dodogang/plume/item/item_group/TabbedItemGroup.java
@@ -30,15 +30,15 @@ public class TabbedItemGroup extends ItemGroup {
     private final Function<Identifier, List<ItemGroupTab>> tabsSupplier;
 
     private final List<ItemGroupTab> tabs = new ArrayList<>();
-    private int selectedTabIndex = 0;
-    private boolean initialized = false;
+    private int selectedTabIndex          = 0;
+    private boolean initialized           = false;
 
     public TabbedItemGroup(Identifier id, Function<Identifier, List<ItemGroupTab>> tabs, Supplier<ItemStack> icon) {
         super(TabbedItemGroup.getItemGroupIndex(id), id.getNamespace() + "." + id.getPath());
 
-        this.id = id;
+        this.id           = id;
         this.tabsSupplier = tabs;
-        this.icon = icon;
+        this.icon         = icon;
     }
     public TabbedItemGroup(String modId, Function<Identifier, List<ItemGroupTab>> tabs, Supplier<ItemStack> icon) {
         this(new Identifier(modId, "title"), tabs, icon);
@@ -50,7 +50,8 @@ public class TabbedItemGroup extends ItemGroup {
     }
 
     public static ItemGroupTab createTab(ItemConvertible item, String modId, String id) {
-        return TabbedItemGroup.createTab(item, modId, id, TagRegistry.item(new Identifier(Plume.MOD_ID, "creative_tabs/" + modId + "/" + id)));
+        return TabbedItemGroup.createTab(
+            item, modId, id, TagRegistry.item(new Identifier(Plume.MOD_ID, "creative_tabs/" + modId + "/" + id)));
     }
     public static ItemGroupTab createTab(ItemConvertible item, String modId, String id, Tag<Item> tag) {
         return TabbedItemGroup.createTab(new ItemStack(item), modId, id, tag);
@@ -121,7 +122,9 @@ public class TabbedItemGroup extends ItemGroup {
 
     @Override
     public Text getTranslationKey() {
-        return this.selectedTabIndex != 0 ? new TranslatableText("itemGroup." + id.getNamespace(), this.getSelectedItemTab().getTranslationKey()) : super.getTranslationKey();
+        return this.selectedTabIndex != 0
+            ? new TranslatableText("itemGroup." + id.getNamespace(), this.getSelectedItemTab().getTranslationKey())
+            : super.getTranslationKey();
     }
 
     @Override

--- a/common/src/main/java/net/dodogang/plume/mixin/AbstractBlockStateMixin.java
+++ b/common/src/main/java/net/dodogang/plume/mixin/AbstractBlockStateMixin.java
@@ -5,6 +5,7 @@ import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.tag.Tag;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;

--- a/common/src/main/java/net/dodogang/plume/mixin/PointOfInterestTypeAccessor.java
+++ b/common/src/main/java/net/dodogang/plume/mixin/PointOfInterestTypeAccessor.java
@@ -3,6 +3,7 @@ package net.dodogang.plume.mixin;
 import net.dodogang.plume.registry.PointOfInterestTypeAppender;
 import net.minecraft.block.BlockState;
 import net.minecraft.world.poi.PointOfInterestType;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
@@ -17,12 +18,10 @@ import java.util.Set;
 public interface PointOfInterestTypeAccessor {
     @Accessor("BLOCK_STATE_TO_POINT_OF_INTEREST_TYPE")
     static Map<BlockState, PointOfInterestType> getBlockStatePoiMap() {
-        throw new AssertionError(); // This will be replaced by mixin with the proper return.
+        throw new AssertionError();  // This will be replaced by mixin with the proper return.
     }
 
-    @Accessor("blockStates")
-    Set<BlockState> getBlockStates();
+    @Accessor("blockStates") Set<BlockState> getBlockStates();
 
-    @Accessor("blockStates")
-    void setBlockStates(Set<BlockState> blockStates);
+    @Accessor("blockStates") void setBlockStates(Set<BlockState> blockStates);
 }

--- a/common/src/main/java/net/dodogang/plume/mixin/client/CreativeInventoryScreenAccessor.java
+++ b/common/src/main/java/net/dodogang/plume/mixin/client/CreativeInventoryScreenAccessor.java
@@ -2,6 +2,7 @@ package net.dodogang.plume.mixin.client;
 
 import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
 import net.minecraft.util.Identifier;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 

--- a/common/src/main/java/net/dodogang/plume/mixin/client/CreativeInventoryScreenMixin.java
+++ b/common/src/main/java/net/dodogang/plume/mixin/client/CreativeInventoryScreenMixin.java
@@ -1,6 +1,7 @@
 package net.dodogang.plume.mixin.client;
 
 import com.google.common.collect.Lists;
+
 import net.dodogang.plume.client.gui.item_group.ItemGroupTabWidget;
 import net.dodogang.plume.item.item_group.TabbedItemGroup;
 import net.fabricmc.api.EnvType;
@@ -12,6 +13,7 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.text.Text;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -21,11 +23,13 @@ import java.util.List;
 
 @Environment(EnvType.CLIENT)
 @Mixin(CreativeInventoryScreen.class)
-public abstract class CreativeInventoryScreenMixin extends AbstractInventoryScreen<CreativeInventoryScreen.CreativeScreenHandler> {
+public abstract class CreativeInventoryScreenMixin
+    extends AbstractInventoryScreen<CreativeInventoryScreen.CreativeScreenHandler> {
     private final List<ItemGroupTabWidget> plume_tabButtons = Lists.newArrayList();
 
     @SuppressWarnings("unused")
-    public CreativeInventoryScreenMixin(CreativeInventoryScreen.CreativeScreenHandler screenHandler, PlayerInventory inventory, Text text) {
+    public CreativeInventoryScreenMixin(
+        CreativeInventoryScreen.CreativeScreenHandler screenHandler, PlayerInventory inventory, Text text) {
         super(screenHandler, inventory, text);
     }
 
@@ -35,13 +39,14 @@ public abstract class CreativeInventoryScreenMixin extends AbstractInventoryScre
         plume_tabButtons.clear();
 
         if (group instanceof TabbedItemGroup) {
-            TabbedItemGroup tab = (TabbedItemGroup) group;
+            TabbedItemGroup tab = (TabbedItemGroup)group;
             if (!tab.isInitialized()) {
                 tab.init();
             }
 
             for (int i = 0; i < tab.getTabs().size(); i++) {
-                ItemGroupTabWidget tabWidget = tab.getTabs().get(i).createWidget(x, y, i, tab, CreativeInventoryScreen.class.cast(this));
+                ItemGroupTabWidget tabWidget =
+                    tab.getTabs().get(i).createWidget(x, y, i, tab, CreativeInventoryScreen.class.cast(this));
 
                 if (i == tab.getSelectedTabIndex()) {
                     tabWidget.isSelected = true;
@@ -62,10 +67,18 @@ public abstract class CreativeInventoryScreenMixin extends AbstractInventoryScre
         });
     }
 
-    @Inject(method = "renderTabIcon", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/CreativeInventoryScreen;drawTexture(Lnet/minecraft/client/util/math/MatrixStack;IIIIII)V", shift = At.Shift.BEFORE))
-    protected void renderTabIcon(MatrixStack matrixStack, ItemGroup itemGroup, CallbackInfo ci) {
+    @Inject(
+        method = "renderTabIcon",
+        at     = @At(
+            value = "INVOKE",
+            target =
+                "Lnet/minecraft/client/gui/screen/ingame/CreativeInventoryScreen;drawTexture(Lnet/minecraft/client/util/math/MatrixStack;IIIIII)V",
+            shift = At.Shift.BEFORE))
+    protected void
+    renderTabIcon(MatrixStack matrixStack, ItemGroup itemGroup, CallbackInfo ci) {
         if (itemGroup instanceof TabbedItemGroup) {
-            MinecraftClient.getInstance().getTextureManager().bindTexture(((TabbedItemGroup) itemGroup).getIconBackgroundTexture());
+            MinecraftClient.getInstance().getTextureManager().bindTexture(
+                ((TabbedItemGroup)itemGroup).getIconBackgroundTexture());
         }
     }
 }

--- a/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/AttachedStemBlockMixin.java
+++ b/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/AttachedStemBlockMixin.java
@@ -5,6 +5,7 @@ import net.minecraft.block.AttachedStemBlock;
 import net.minecraft.block.BlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockView;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;

--- a/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/CropBlockMixin.java
+++ b/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/CropBlockMixin.java
@@ -5,6 +5,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.CropBlock;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockView;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;

--- a/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/DeadBushBlockMixin.java
+++ b/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/DeadBushBlockMixin.java
@@ -5,6 +5,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.DeadBushBlock;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockView;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;

--- a/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/FeatureMixin.java
+++ b/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/FeatureMixin.java
@@ -3,6 +3,7 @@ package net.dodogang.plume.mixin.supporters_tags;
 import net.dodogang.plume.tag.PlumeBlockTags;
 import net.minecraft.block.Block;
 import net.minecraft.world.gen.feature.Feature;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;

--- a/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/FungusBlockMixin.java
+++ b/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/FungusBlockMixin.java
@@ -5,6 +5,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.FungusBlock;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockView;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;

--- a/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/NetherWartBlockMixin.java
+++ b/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/NetherWartBlockMixin.java
@@ -5,6 +5,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.NetherWartBlock;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockView;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;

--- a/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/PlantBlockMixin.java
+++ b/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/PlantBlockMixin.java
@@ -5,6 +5,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.PlantBlock;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockView;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;

--- a/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/RootsBlockMixin.java
+++ b/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/RootsBlockMixin.java
@@ -5,6 +5,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.RootsBlock;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockView;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;

--- a/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/SproutsBlockMixin.java
+++ b/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/SproutsBlockMixin.java
@@ -5,6 +5,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.SproutsBlock;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockView;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;

--- a/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/StemBlockMixin.java
+++ b/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/StemBlockMixin.java
@@ -5,6 +5,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.StemBlock;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockView;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;

--- a/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/WitherRoseBlockMixin.java
+++ b/common/src/main/java/net/dodogang/plume/mixin/supporters_tags/WitherRoseBlockMixin.java
@@ -5,6 +5,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.WitherRoseBlock;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockView;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;

--- a/common/src/main/java/net/dodogang/plume/registry/BlockRegistryBatch.java
+++ b/common/src/main/java/net/dodogang/plume/registry/BlockRegistryBatch.java
@@ -8,6 +8,7 @@ import net.minecraft.block.Block;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
 import net.minecraft.util.registry.Registry;
+
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
@@ -20,8 +21,8 @@ public final class BlockRegistryBatch {
     protected Item.Settings defaultSettings;
 
     public BlockRegistryBatch(String modId) {
-        this.blockRegistry = RegistryBatch.create(Registry.BLOCK_KEY, modId);
-        this.itemRegistry = RegistryBatch.create(Registry.ITEM_KEY, modId);
+        this.blockRegistry   = RegistryBatch.create(Registry.BLOCK_KEY, modId);
+        this.itemRegistry    = RegistryBatch.create(Registry.ITEM_KEY, modId);
         this.defaultSettings = new Item.Settings();
     }
 
@@ -47,7 +48,7 @@ public final class BlockRegistryBatch {
      * @param settings the {@link Item.Settings} that will make the block item.
      * @return a {@link RegistrySupplier} containing the id of the block
      */
-    public <B extends Block>RegistrySupplier<B> add(String name, B block, @Nullable Item.Settings settings) {
+    public <B extends Block> RegistrySupplier<B> add(String name, B block, @Nullable Item.Settings settings) {
         if (settings != null) {
             this.itemRegistry.add(name, new BlockItem(block, settings));
         }
@@ -63,7 +64,7 @@ public final class BlockRegistryBatch {
      * @param block the block to be registered
      * @return a {@link RegistrySupplier} containing the id of the block
      */
-    public <B extends Block>RegistrySupplier<B> add(String name, B block) {
+    public <B extends Block> RegistrySupplier<B> add(String name, B block) {
         return add(name, block, this.defaultSettings);
     }
 
@@ -78,10 +79,7 @@ public final class BlockRegistryBatch {
      * @return a {@link RegistrySupplier} containing the id of the block
      */
     public <B extends Block> RegistrySupplier<B> addCopy(
-            String name,
-            Function<AbstractBlock.Settings, B> blockFunction,
-            AbstractBlock toCopy
-    ) {
+        String name, Function<AbstractBlock.Settings, B> blockFunction, AbstractBlock toCopy) {
         return this.add(name, blockFunction.apply(AbstractBlock.Settings.copy(toCopy)));
     }
 

--- a/common/src/main/java/net/dodogang/plume/registry/PointOfInterestTypeAppender.java
+++ b/common/src/main/java/net/dodogang/plume/registry/PointOfInterestTypeAppender.java
@@ -1,6 +1,7 @@
 package net.dodogang.plume.registry;
 
 import com.google.common.collect.ImmutableSet;
+
 import net.dodogang.plume.mixin.PointOfInterestTypeAccessor;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -13,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 public final class PointOfInterestTypeAppender {
-    private PointOfInterestTypeAppender() {}
+    private PointOfInterestTypeAppender() { }
 
     /**
      * Appends the given block states onto the list of block states for a
@@ -33,13 +34,12 @@ public final class PointOfInterestTypeAppender {
             // A state can only be in one PointOfInterestType, so we throw an error.
             if (previousPoiType != null) {
                 throw Util.throwOrPause(new IllegalStateException(
-                        String.format("%s is defined for too many PointOfInterestTypes.", state)
-                ));
+                    String.format("%s is defined for too many PointOfInterestTypes.", state)));
             }
         }
 
         // Get mutable access to poiType's blockState set.
-        PointOfInterestTypeAccessor poiTypeAccessor = (PointOfInterestTypeAccessor) poiType;
+        PointOfInterestTypeAccessor poiTypeAccessor = (PointOfInterestTypeAccessor)poiType;
 
         // Copy the set and add our states to the list.
         List<BlockState> blockStates = new ArrayList<>(poiTypeAccessor.getBlockStates());

--- a/common/src/main/java/net/dodogang/plume/screen/PlumeCraftingScreenHandler.java
+++ b/common/src/main/java/net/dodogang/plume/screen/PlumeCraftingScreenHandler.java
@@ -10,10 +10,11 @@ public class PlumeCraftingScreenHandler extends CraftingScreenHandler {
     private final ScreenHandlerContext context;
     private final Block block;
 
-    public PlumeCraftingScreenHandler(int syncId, PlayerInventory inventory, ScreenHandlerContext context, Block block) {
+    public PlumeCraftingScreenHandler(
+        int syncId, PlayerInventory inventory, ScreenHandlerContext context, Block block) {
         super(syncId, inventory, context);
         this.context = context;
-        this.block = block;
+        this.block   = block;
     }
 
     @Override

--- a/common/src/main/java/net/dodogang/plume/tag/PlumeBlockTags.java
+++ b/common/src/main/java/net/dodogang/plume/tag/PlumeBlockTags.java
@@ -58,6 +58,6 @@ public class PlumeBlockTags {
     public static final Tag.Identified<Block> FEATURE_SUPPORTERS_STONE = register("feature_supporters_stone");
 
     private static Tag.Identified<Block> register(String id) {
-        return (Tag.Identified<Block>) TagRegistry.block(new Identifier(Plume.MOD_ID, id));
+        return (Tag.Identified<Block>)TagRegistry.block(new Identifier(Plume.MOD_ID, id));
     }
 }

--- a/fabric/src/main/java/net/dodogang/plume/ash/client/registry/fabric/BlockEntityRendererRegistryImpl.java
+++ b/fabric/src/main/java/net/dodogang/plume/ash/client/registry/fabric/BlockEntityRendererRegistryImpl.java
@@ -5,6 +5,7 @@ import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher;
 import net.minecraft.client.render.block.entity.BlockEntityRenderer;
+
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.function.Function;
@@ -19,9 +20,7 @@ public final class BlockEntityRendererRegistryImpl {
      * @param <T> extends BlockEntity
      */
     public static <T extends BlockEntity> void register(
-            BlockEntityType<T> beType,
-            Function<BlockEntityRenderDispatcher, BlockEntityRenderer<? super T>> renderer
-    ) {
+        BlockEntityType<T> beType, Function<BlockEntityRenderDispatcher, BlockEntityRenderer<? super T>> renderer) {
         BlockEntityRendererRegistry.INSTANCE.register(beType, renderer);
     }
 }

--- a/fabric/src/main/java/net/dodogang/plume/ash/client/registry/fabric/BuiltinItemRendererRegistryImpl.java
+++ b/fabric/src/main/java/net/dodogang/plume/ash/client/registry/fabric/BuiltinItemRendererRegistryImpl.java
@@ -3,6 +3,7 @@ package net.dodogang.plume.ash.client.registry.fabric;
 import net.dodogang.plume.ash.client.registry.BuiltinItemRendererRegistry.DynamicItemRenderer;
 import net.fabricmc.fabric.api.client.rendering.v1.BuiltinItemRendererRegistry;
 import net.minecraft.item.ItemConvertible;
+
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal

--- a/fabric/src/main/java/net/dodogang/plume/ash/client/registry/fabric/RenderLayerRegistryImpl.java
+++ b/fabric/src/main/java/net/dodogang/plume/ash/client/registry/fabric/RenderLayerRegistryImpl.java
@@ -4,6 +4,7 @@ import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
 import net.minecraft.block.Block;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.fluid.Fluid;
+
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal

--- a/fabric/src/main/java/net/dodogang/plume/ash/client/registry/fabric/SpriteRegistryImpl.java
+++ b/fabric/src/main/java/net/dodogang/plume/ash/client/registry/fabric/SpriteRegistryImpl.java
@@ -3,6 +3,7 @@ package net.dodogang.plume.ash.client.registry.fabric;
 import net.fabricmc.fabric.api.event.client.ClientSpriteRegistryCallback;
 import net.minecraft.client.render.TexturedRenderLayers;
 import net.minecraft.util.Identifier;
+
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal

--- a/fabric/src/main/java/net/dodogang/plume/ash/event/fabric/InteractionCallbackImpl.java
+++ b/fabric/src/main/java/net/dodogang/plume/ash/event/fabric/InteractionCallbackImpl.java
@@ -3,6 +3,7 @@ package net.dodogang.plume.ash.event.fabric;
 import net.dodogang.plume.ash.event.InteractionCallback;
 import net.fabricmc.fabric.api.event.player.UseBlockCallback;
 import net.minecraft.util.ActionResult;
+
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal

--- a/fabric/src/main/java/net/dodogang/plume/ash/fabric/EnvironmentImpl.java
+++ b/fabric/src/main/java/net/dodogang/plume/ash/fabric/EnvironmentImpl.java
@@ -2,6 +2,7 @@ package net.dodogang.plume.ash.fabric;
 
 import net.dodogang.plume.ash.Platform;
 import net.fabricmc.loader.api.FabricLoader;
+
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal

--- a/fabric/src/main/java/net/dodogang/plume/ash/registry/fabric/FuelRegistryImpl.java
+++ b/fabric/src/main/java/net/dodogang/plume/ash/registry/fabric/FuelRegistryImpl.java
@@ -2,6 +2,7 @@ package net.dodogang.plume.ash.registry.fabric;
 
 import net.dodogang.plume.ash.registry.FuelRegistry;
 import net.minecraft.item.ItemConvertible;
+
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal

--- a/fabric/src/main/java/net/dodogang/plume/ash/registry/fabric/ItemGroupBuilderImpl.java
+++ b/fabric/src/main/java/net/dodogang/plume/ash/registry/fabric/ItemGroupBuilderImpl.java
@@ -4,6 +4,7 @@ import net.dodogang.plume.ash.registry.ItemGroupBuilder;
 import net.fabricmc.fabric.api.client.itemgroup.FabricItemGroupBuilder;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.util.Identifier;
+
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
@@ -29,9 +30,6 @@ public final class ItemGroupBuilderImpl extends ItemGroupBuilder {
      */
     @Override
     public ItemGroup build() {
-        return FabricItemGroupBuilder.create(id)
-                .icon(iconSupplier)
-                .appendItems(stacksToDisplay)
-                .build();
+        return FabricItemGroupBuilder.create(id).icon(iconSupplier).appendItems(stacksToDisplay).build();
     }
 }

--- a/fabric/src/main/java/net/dodogang/plume/ash/registry/fabric/RegistryBatchImpl.java
+++ b/fabric/src/main/java/net/dodogang/plume/ash/registry/fabric/RegistryBatchImpl.java
@@ -5,6 +5,7 @@ import net.dodogang.plume.ash.registry.RegistrySupplier;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.RegistryKey;
+
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal

--- a/fabric/src/main/java/net/dodogang/plume/ash/tag/fabric/TagRegistryImpl.java
+++ b/fabric/src/main/java/net/dodogang/plume/ash/tag/fabric/TagRegistryImpl.java
@@ -6,6 +6,7 @@ import net.minecraft.fluid.Fluid;
 import net.minecraft.item.Item;
 import net.minecraft.tag.Tag;
 import net.minecraft.util.Identifier;
+
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal

--- a/fabric/src/main/java/net/dodogang/plume/ash/tag/fabric/ToolTagsImpl.java
+++ b/fabric/src/main/java/net/dodogang/plume/ash/tag/fabric/ToolTagsImpl.java
@@ -3,11 +3,12 @@ package net.dodogang.plume.ash.tag.fabric;
 import net.dodogang.plume.ash.tag.ToolTags;
 import net.fabricmc.fabric.api.tool.attribute.v1.FabricToolTags;
 import net.minecraft.item.ItemStack;
+
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
 public final class ToolTagsImpl {
-    private ToolTagsImpl() {}
+    private ToolTagsImpl() { }
 
     public static boolean containsImpl(ToolTags tag, ItemStack stack) {
         switch (tag) {

--- a/forge/src/main/java/net/dodogang/plume/ash/client/registry/forge/BlockEntityRendererRegistryImpl.java
+++ b/forge/src/main/java/net/dodogang/plume/ash/client/registry/forge/BlockEntityRendererRegistryImpl.java
@@ -5,6 +5,7 @@ import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher;
 import net.minecraft.client.render.block.entity.BlockEntityRenderer;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
+
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.function.Function;
@@ -19,9 +20,7 @@ public final class BlockEntityRendererRegistryImpl {
      * @param <T> extends BlockEntity
      */
     public static <T extends BlockEntity> void register(
-            BlockEntityType<T> beType, Function<BlockEntityRenderDispatcher,
-            BlockEntityRenderer<T>> renderer
-    ) {
+        BlockEntityType<T> beType, Function<BlockEntityRenderDispatcher, BlockEntityRenderer<T>> renderer) {
         ClientRegistry.bindTileEntityRenderer(beType, renderer);
     }
 }

--- a/forge/src/main/java/net/dodogang/plume/ash/client/registry/forge/BuiltinItemRendererRegistryImpl.java
+++ b/forge/src/main/java/net/dodogang/plume/ash/client/registry/forge/BuiltinItemRendererRegistryImpl.java
@@ -8,6 +8,7 @@ import net.minecraft.client.render.model.json.ModelTransformation;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.item.ItemConvertible;
 import net.minecraft.item.ItemStack;
+
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
@@ -33,13 +34,8 @@ public final class BuiltinItemRendererRegistryImpl {
 
         @Override
         public void render(
-                ItemStack stack,
-                ModelTransformation.Mode mode,
-                MatrixStack matrices,
-                VertexConsumerProvider vertexConsumers,
-                int light,
-                int overlay
-        ) {
+            ItemStack stack, ModelTransformation.Mode mode, MatrixStack matrices,
+            VertexConsumerProvider vertexConsumers, int light, int overlay) {
             renderer.render(stack, mode, matrices, vertexConsumers, light, overlay);
         }
     }

--- a/forge/src/main/java/net/dodogang/plume/ash/client/registry/forge/RenderLayerRegistryImpl.java
+++ b/forge/src/main/java/net/dodogang/plume/ash/client/registry/forge/RenderLayerRegistryImpl.java
@@ -4,6 +4,7 @@ import net.minecraft.block.Block;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.RenderLayers;
 import net.minecraft.fluid.Fluid;
+
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal

--- a/forge/src/main/java/net/dodogang/plume/ash/client/registry/forge/SpriteRegistryImpl.java
+++ b/forge/src/main/java/net/dodogang/plume/ash/client/registry/forge/SpriteRegistryImpl.java
@@ -4,6 +4,7 @@ import net.dodogang.plume.ash.forge.ModEventBus;
 import net.minecraft.client.render.TexturedRenderLayers;
 import net.minecraft.util.Identifier;
 import net.minecraftforge.client.event.TextureStitchEvent;
+
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal

--- a/forge/src/main/java/net/dodogang/plume/ash/event/forge/InteractionCallbackImpl.java
+++ b/forge/src/main/java/net/dodogang/plume/ash/event/forge/InteractionCallbackImpl.java
@@ -4,6 +4,7 @@ import net.dodogang.plume.ash.event.InteractionCallback;
 import net.minecraft.util.ActionResult;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal

--- a/forge/src/main/java/net/dodogang/plume/ash/forge/EnvironmentImpl.java
+++ b/forge/src/main/java/net/dodogang/plume/ash/forge/EnvironmentImpl.java
@@ -2,6 +2,7 @@ package net.dodogang.plume.ash.forge;
 
 import net.dodogang.plume.ash.Platform;
 import net.minecraftforge.fml.loading.FMLLoader;
+
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal

--- a/forge/src/main/java/net/dodogang/plume/ash/forge/ModEventBus.java
+++ b/forge/src/main/java/net/dodogang/plume/ash/forge/ModEventBus.java
@@ -1,6 +1,7 @@
 package net.dodogang.plume.ash.forge;
 
 import net.minecraftforge.eventbus.api.IEventBus;
+
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.HashMap;
@@ -15,7 +16,7 @@ import java.util.Optional;
  * ModEventBus.registerModEventBus("mod_id", FMLJavaModLoadingContext.get().getModEventBus());
  */
 public final class ModEventBus {
-    private ModEventBus() {}
+    private ModEventBus() { }
 
     private static final HashMap<String, IEventBus> MOD_EVENT_BUSES = new HashMap<>();
 
@@ -38,7 +39,6 @@ public final class ModEventBus {
 
     public static IEventBus getModEventBusOrThrow(String modId) {
         return getModEventBus(modId).orElseThrow(
-                () -> new IllegalStateException("Mod Event Bus for modid '" + modId + "' has not been registered.")
-        );
+            () -> new IllegalStateException("Mod Event Bus for modid '" + modId + "' has not been registered."));
     }
 }

--- a/forge/src/main/java/net/dodogang/plume/ash/mixin/client/forge/ItemAccessor.java
+++ b/forge/src/main/java/net/dodogang/plume/ash/mixin/client/forge/ItemAccessor.java
@@ -2,6 +2,7 @@ package net.dodogang.plume.ash.mixin.client.forge;
 
 import net.minecraft.client.render.item.BuiltinModelItemRenderer;
 import net.minecraft.item.Item;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
@@ -15,6 +16,5 @@ public interface ItemAccessor {
      * This might be replaced in the future with a better abstraction.
      */
     // remap = false because this field is part of a forge patch and doesn't get remapped.
-    @Accessor(value = "ister", remap = false)
-    void setIster(Supplier<BuiltinModelItemRenderer> ister);
+    @Accessor(value = "ister", remap = false) void setIster(Supplier<BuiltinModelItemRenderer> ister);
 }

--- a/forge/src/main/java/net/dodogang/plume/ash/registry/forge/FuelRegistryImpl.java
+++ b/forge/src/main/java/net/dodogang/plume/ash/registry/forge/FuelRegistryImpl.java
@@ -6,6 +6,7 @@ import net.minecraft.item.ItemConvertible;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.event.furnace.FurnaceFuelBurnTimeEvent;
+
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.HashMap;

--- a/forge/src/main/java/net/dodogang/plume/ash/registry/forge/ItemGroupBuilderImpl.java
+++ b/forge/src/main/java/net/dodogang/plume/ash/registry/forge/ItemGroupBuilderImpl.java
@@ -5,6 +5,7 @@ import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.collection.DefaultedList;
+
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal

--- a/forge/src/main/java/net/dodogang/plume/ash/registry/forge/RegistryBatchImpl.java
+++ b/forge/src/main/java/net/dodogang/plume/ash/registry/forge/RegistryBatchImpl.java
@@ -10,6 +10,7 @@ import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.IForgeRegistryEntry;
 import net.minecraftforge.registries.RegistryManager;
+
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
@@ -50,9 +51,11 @@ public final class RegistryBatchImpl<T extends IForgeRegistryEntry<T>> extends R
 
     @Override
     protected void registerImpl() {
-        IEventBus modEventBus = ModEventBus.getModEventBus(modId).orElseThrow(() -> new IllegalStateException(
-                "Attempted to register BatchedRegister before registering a ModEventBus for modid '" + modId + "'.")
-        );
+        IEventBus modEventBus = ModEventBus.getModEventBus(modId).orElseThrow(
+            ()
+                -> new IllegalStateException(
+                    "Attempted to register BatchedRegister before registering a ModEventBus for modid '" + modId
+                    + "'."));
         deferredRegister.register(modEventBus);
     }
 }

--- a/forge/src/main/java/net/dodogang/plume/ash/tag/forge/TagRegistryImpl.java
+++ b/forge/src/main/java/net/dodogang/plume/ash/tag/forge/TagRegistryImpl.java
@@ -6,6 +6,7 @@ import net.minecraft.fluid.Fluid;
 import net.minecraft.item.Item;
 import net.minecraft.tag.*;
 import net.minecraft.util.Identifier;
+
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal

--- a/forge/src/main/java/net/dodogang/plume/ash/tag/forge/ToolTagsImpl.java
+++ b/forge/src/main/java/net/dodogang/plume/ash/tag/forge/ToolTagsImpl.java
@@ -5,13 +5,14 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.ShearsItem;
 import net.minecraft.item.SwordItem;
 import net.minecraftforge.common.ToolType;
+
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Set;
 
 @ApiStatus.Internal
 public final class ToolTagsImpl {
-    private ToolTagsImpl() {}
+    private ToolTagsImpl() { }
 
     public static boolean containsImpl(ToolTags tag, ItemStack stack) {
         Set<ToolType> toolTypes = stack.getItem().getToolTypes(stack);


### PR DESCRIPTION
This is an attempt to standardize our code style choices.
It uses clang-format (can be installed on linux with the clang package) to automatically format the code.

To run for all files on linux:
```bash
find -iname *.java | xargs clang-format -i
```

Clang settings can be found in `./.clang-format` and for further information look at [Clang-Format 11 Style Options](https://releases.llvm.org/11.0.0/tools/clang/docs/ClangFormatStyleOptions.html)